### PR TITLE
Add CLI entry point and convenience API for HAIRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ pip install -r requirements.txt  # (not required for the standard-library-only d
 pytest
 ```
 
+### Command-line usage
+
+The project exposes a lightweight CLI so you can run the framework without
+writing Python code:
+
+```bash
+python -m hairf --open-think-pro "How does adaptive routing allocate compute?"
+```
+
+Use `--show-traces` to include per-module traces or `--summary` to print the
+running performance summary collected by the default framework instance.
+
+### Python API convenience helpers
+
+When importing the package you can call `hairf.answer_question` to route a
+question through a cached :class:`hairf.framework.HAIRF` instance:
+
+```python
+from hairf import answer_question
+
+result = answer_question("Explain compute-optimal scheduling.")
+print(result.answer)
+```
+
 The unit tests validate that the router increases compute allocation for harder prompts, ensuring that the compute-optimal scheduler is wired into the decision flow.
 
 ## References

--- a/hairf/__init__.py
+++ b/hairf/__init__.py
@@ -15,6 +15,7 @@ from .router import AdaptiveRouter, RoutingDecision
 from .compute_optimal import ComputeOptimalBudgeter, ComputePlan
 from .engine import ModularExecutionEngine
 from .aggregator import OutputAggregator
+from .api import answer_question, get_default_framework
 from .framework import HAIRF
 from .learning import ExperienceReplayLearner
 from .inference import LLMConfig, ensure_llm_config, generate_text
@@ -26,6 +27,8 @@ __all__ = [
     "DynamicContextualMemoryNetwork",
     "ExperienceReplayLearner",
     "HAIRF",
+    "answer_question",
+    "get_default_framework",
     "ModularExecutionEngine",
     "OutputAggregator",
     "QIRAReasoner",

--- a/hairf/__main__.py
+++ b/hairf/__main__.py
@@ -1,0 +1,13 @@
+"""Module entry point for ``python -m hairf``."""
+
+from __future__ import annotations
+
+from .cli import run_cli
+
+
+def main() -> None:
+    raise SystemExit(run_cli())
+
+
+if __name__ == "__main__":
+    main()

--- a/hairf/api.py
+++ b/hairf/api.py
@@ -1,0 +1,61 @@
+"""High-level convenience functions for interacting with HAIRF."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .framework import HAIRF
+from .types import Query, ReasoningResult
+
+_DEFAULT_FRAMEWORK: HAIRF | None = None
+
+
+def get_default_framework(*, default_llm: Any | None = None, reset: bool = False) -> HAIRF:
+    """Return a process-wide :class:`HAIRF` instance.
+
+    Parameters
+    ----------
+    default_llm:
+        Optional configuration used when instantiating the framework.  When
+        provided alongside ``reset=True`` a new :class:`HAIRF` instance is
+        created using the configuration.
+    reset:
+        If ``True`` the existing cached framework is discarded and a new one is
+        created.  This is primarily useful for tests that need isolation.
+    """
+
+    global _DEFAULT_FRAMEWORK
+
+    if reset or _DEFAULT_FRAMEWORK is None:
+        _DEFAULT_FRAMEWORK = HAIRF(default_llm=default_llm)
+    return _DEFAULT_FRAMEWORK
+
+
+def answer_question(
+    question: str,
+    *,
+    llm: Any | None = None,
+    framework: HAIRF | None = None,
+) -> ReasoningResult:
+    """Run the HAIRF pipeline for ``question`` and return the result.
+
+    Parameters
+    ----------
+    question:
+        Natural-language question to be processed by the framework.  Leading
+        and trailing whitespace is ignored and the question must be non-empty.
+    llm:
+        Optional LLM configuration passed through to :meth:`HAIRF.process`.
+        Strings are interpreted as model identifiers, while dictionaries can
+        provide richer configuration.
+    framework:
+        Optional pre-configured :class:`HAIRF` instance.  When omitted a
+        singleton instance managed by :func:`get_default_framework` is used.
+    """
+
+    if not question or not question.strip():
+        raise ValueError("question must be a non-empty string")
+
+    hairf = framework if framework is not None else get_default_framework()
+    query = Query(text=question.strip())
+    return hairf.process(query, llm=llm)

--- a/hairf/cli.py
+++ b/hairf/cli.py
@@ -1,0 +1,112 @@
+"""Command line interface for the HAIRF framework."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Iterable
+
+from .api import answer_question, get_default_framework
+from .types import ModuleTrace, ReasoningState
+
+
+def _format_states(states: Iterable[ReasoningState]) -> str:
+    lines = []
+    for state in states:
+        lines.append(f"- {state.content} (confidence={state.confidence:.2f}, cost={state.cost:.2f})")
+    return "\n".join(lines)
+
+
+def _format_traces(traces: Iterable[ModuleTrace]) -> str:
+    rendered = []
+    for trace in traces:
+        header = f"Module: {trace.module}"
+        rendered.append(header)
+        if trace.states:
+            rendered.append(_format_states(trace.states))
+        if trace.info:
+            rendered.append(f"  info: {json.dumps(trace.info, sort_keys=True)}")
+    return "\n".join(rendered)
+
+
+def run_cli(argv: list[str] | None = None) -> int:
+    """Entry point used by ``python -m hairf`` and the console script."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the Hybrid Adaptive Inference Reasoning Framework (HAIRF) for a "
+            "single natural-language question."
+        )
+    )
+    parser.add_argument(
+        "--open-think-pro",
+        "-q",
+        dest="question",
+        metavar="QUESTION",
+        help="Question or prompt to send through the HAIRF pipeline.",
+    )
+    parser.add_argument(
+        "--llm",
+        dest="llm",
+        metavar="LLM",
+        help=(
+            "Optional LLM configuration. Provide a model name or a JSON object "
+            "with configuration settings."
+        ),
+    )
+    parser.add_argument(
+        "--show-traces",
+        action="store_true",
+        help="Include intermediate module traces in the output.",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print a performance summary gathered from the default framework.",
+    )
+
+    args = parser.parse_args(argv)
+
+    if not args.question:
+        parser.error("the following arguments are required: --open-think-pro")
+
+    llm_config: Any | None = None
+    if args.llm:
+        llm_config = _parse_llm_argument(args.llm)
+
+    result = answer_question(args.question, llm=llm_config)
+
+    print("Answer:")
+    print(result.answer)
+    print()
+    print(f"Confidence: {result.confidence:.2%}")
+    print(f"Estimated tokens used: {result.used_tokens}")
+
+    if args.show_traces and result.traces:
+        print()
+        print("Traces:")
+        print(_format_traces(result.traces))
+
+    if args.summary:
+        framework = get_default_framework()
+        print()
+        print(framework.summary())
+
+    return 0
+
+
+def _parse_llm_argument(raw: str) -> Any:
+    """Interpret ``raw`` as JSON when possible, otherwise return it verbatim."""
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    if isinstance(parsed, dict):
+        if "model" in parsed and "provider" not in parsed:
+            parsed = {**parsed, "provider": "custom"}
+        return parsed
+    return parsed
+
+
+__all__ = ["run_cli"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from hairf import answer_question, get_default_framework
+
+
+@pytest.fixture(autouse=True)
+def reset_framework():
+    get_default_framework(reset=True)
+    yield
+    get_default_framework(reset=True)
+
+
+def test_answer_question_returns_reasoning_result():
+    result = answer_question("Summarize adaptive routing strategies.")
+    assert result.answer
+    assert 0.0 <= result.confidence <= 1.0
+
+
+def test_cli_invocation_returns_output(tmp_path):
+    question = "What is the purpose of the compute-optimal budgeter?"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hairf",
+            "--open-think-pro",
+            question,
+            "--show-traces",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    stdout = completed.stdout
+    assert "Answer:" in stdout
+    assert "Confidence:" in stdout
+    assert question[:20] not in completed.stderr
+
+
+def test_cli_accepts_json_llm_configuration():
+    config = {"model": "demo-llm", "temperature": 0.2}
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hairf",
+            "--open-think-pro",
+            "Explain the learner.",
+            "--llm",
+            json.dumps(config),
+            "--summary",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "HAIRF Summary" in completed.stdout


### PR DESCRIPTION
## Summary
- add a cached default HAIRF instance and an `answer_question` helper for module consumers
- implement a CLI entry point with `--open-think-pro` along with trace and summary options
- document usage updates and add tests covering the CLI and convenience API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ccc59720c0832aa2dd4f75d5c3667c